### PR TITLE
Added .ifFailed(Non)AbsentSendTo to Result

### DIFF
--- a/agera/src/main/java/com/google/android/agera/Result.java
+++ b/agera/src/main/java/com/google/android/agera/Result.java
@@ -207,6 +207,35 @@ public final class Result<T> {
     return this;
   }
 
+
+  /**
+   * Passes the encountered failure to the {@code receiver} if the failure is absent; otherwise
+   * does nothing.
+   *
+   * @return This instance, for chaining.
+   */
+  @NonNull
+  public Result<T> ifAbsentFailureSendTo(@NonNull final Receiver<? super Throwable> receiver) {
+    if (failure != null && failure == ABSENT.failure) {
+      receiver.accept(failure);
+    }
+    return this;
+  }
+
+  /**
+   * Passes the encountered failure to the {@code receiver} if the attempt has failed, except for
+   * the failure absent; otherwise does nothing.
+   *
+   * @return This instance, for chaining.
+   */
+  @NonNull
+  public Result<T> ifNonAbsentFailureSendTo(@NonNull final Receiver<? super Throwable> receiver) {
+    if (failure != null && failure != ABSENT.failure) {
+      receiver.accept(failure);
+    }
+    return this;
+  }
+
   /**
    * Binds the output value with {@code bindValue} using {@code binder} if the attempt has
    * succeeded; otherwise does nothing.

--- a/agera/src/test/java/com/google/android/agera/ResultTest.java
+++ b/agera/src/test/java/com/google/android/agera/ResultTest.java
@@ -281,6 +281,48 @@ public final class ResultTest {
   }
 
   @Test
+  public void shouldApplySendIfFailedExceptAbsent() {
+    failure(THROWABLE).ifNonAbsentFailureSendTo(mockThrowableReceiver);
+
+    verify(mockThrowableReceiver).accept(THROWABLE);
+  }
+
+  @Test
+  public void shouldNotApplySendIfFailedIfSucceeded() {
+    SUCCESS_WITH_VALUE.ifFailedSendTo(mockThrowableReceiver);
+
+    verifyZeroInteractions(mockThrowableReceiver);
+  }
+
+  @Test
+  public void shouldNotApplySendIfFailedExceptAbsentIfSucceeded() {
+    SUCCESS_WITH_VALUE.ifFailedSendTo(mockThrowableReceiver);
+
+    verifyZeroInteractions(mockThrowableReceiver);
+  }
+
+  @Test
+  public void shouldNotApplySendIfFailedExceptAbsentIfAbsent() {
+    absent().ifNonAbsentFailureSendTo(mockThrowableReceiver);
+
+    verifyZeroInteractions(mockThrowableReceiver);
+  }
+
+  @Test
+  public void shouldApplySendIfFailedAbsent() {
+    absent().ifAbsentFailureSendTo(mockThrowableReceiver);
+
+    verify(mockThrowableReceiver).accept(absent().getFailure());
+  }
+
+  @Test
+  public void shouldNotApplySendIfFailedAbsentIfAbsent() {
+    failure(THROWABLE).ifAbsentFailureSendTo(mockThrowableReceiver);
+
+    verifyZeroInteractions(mockThrowableReceiver);
+  }
+
+  @Test
   public void shouldAllowForChainedCallsToSendIfFailed() {
     assertThat(SUCCESS_WITH_VALUE.ifSucceededSendTo(mockReceiver),
         sameInstance(SUCCESS_WITH_VALUE));


### PR DESCRIPTION
Most commonly absent is simply a value that hasn’t arrive yet. For error handling it’s useful to easily be able to filter out these errors. Also, similarly absent can be filtered out.