### PR TITLE
Changed observable activated to be called immediately

### DIFF
--- a/agera/src/test/java/com/google/android/agera/RepositoriesTest.java
+++ b/agera/src/test/java/com/google/android/agera/RepositoriesTest.java
@@ -29,6 +29,7 @@ import static com.google.android.agera.test.mocks.MockUpdatable.mockUpdatable;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -336,7 +337,7 @@ public final class RepositoriesTest {
 
     updatable.addToObservable(repository);
 
-    verify(mockIntegerListToIntValueFunction).apply(LIST);
+    verify(mockIntegerListToIntValueFunction, atLeastOnce()).apply(LIST);
     assertThat(repository, has(INT_VALUE));
   }
 


### PR DESCRIPTION
When adding an updatable observableActivated is now called immediately
if the updatable is added from the same looper as the observable is
operating on