### PR TITLE
Improved BaseObservable performance

### DIFF
--- a/agera/src/main/java/com/google/android/agera/BaseObservable.java
+++ b/agera/src/main/java/com/google/android/agera/BaseObservable.java
@@ -43,12 +43,14 @@ public abstract class BaseObservable implements Observable {
   private static final Object[] NO_UPDATABLES_OR_HANDLERS = new Object[0];
   @NonNull
   private final WorkerHandler handler;
+  @NonNull
+  private final Object token = new Object();
   private final int shortestUpdateWindowMillis;
-
   @NonNull
   private Object[] updatablesAndHandlers;
   private int size;
   private long lastUpdateTimestamp;
+  private boolean pendingUpdate = false;
 
   protected BaseObservable() {
     this(0);
@@ -63,27 +65,32 @@ public abstract class BaseObservable implements Observable {
   }
 
   @Override
-  public synchronized final void addUpdatable(@NonNull final Updatable updatable) {
+  public final void addUpdatable(@NonNull final Updatable updatable) {
     checkState(Looper.myLooper() != null, "Can only be added on a Looper thread");
     checkNotNull(updatable);
-    add(updatable, workerHandler());
-    if (size == 1) {
-      if (handler.hasMessages(MSG_LAST_REMOVED, this)) {
-        handler.removeMessages(MSG_LAST_REMOVED, this);
-      } else {
-        handler.obtainMessage(WorkerHandler.MSG_FIRST_ADDED, this).sendToTarget();
+    synchronized (token) {
+      add(updatable, workerHandler());
+      if (size == 1) {
+        if (handler.hasMessages(MSG_LAST_REMOVED, this)) {
+          handler.removeMessages(MSG_LAST_REMOVED, this);
+        } else {
+          handler.obtainMessage(WorkerHandler.MSG_FIRST_ADDED, this).sendToTarget();
+        }
       }
     }
   }
 
   @Override
-  public synchronized final void removeUpdatable(@NonNull final Updatable updatable) {
+  public final void removeUpdatable(@NonNull final Updatable updatable) {
     checkState(Looper.myLooper() != null, "Can only be removed on a Looper thread");
     checkNotNull(updatable);
-    remove(updatable);
-    if (size == 0) {
-      handler.obtainMessage(MSG_LAST_REMOVED, this).sendToTarget();
-      handler.removeMessages(MSG_UPDATE, this);
+    synchronized (token) {
+      remove(updatable);
+      if (size == 0) {
+        handler.obtainMessage(MSG_LAST_REMOVED, this).sendToTarget();
+        handler.removeMessages(MSG_UPDATE, this);
+        pendingUpdate = false;
+      }
     }
   }
 
@@ -91,11 +98,13 @@ public abstract class BaseObservable implements Observable {
    * Notifies all registered {@link Updatable}s.
    */
   protected final void dispatchUpdate() {
-    if (!handler.hasMessages(MSG_UPDATE, this)) {
-      handler.obtainMessage(MSG_UPDATE, this).sendToTarget();
+    synchronized (token) {
+      if (!pendingUpdate) {
+        pendingUpdate = true;
+        handler.obtainMessage(MSG_UPDATE, this).sendToTarget();
+      }
     }
   }
-
 
   private void add(@NonNull final Updatable updatable, @NonNull final Handler handler) {
     int indexToAdd = -1;
@@ -120,8 +129,8 @@ public abstract class BaseObservable implements Observable {
   private void remove(@NonNull final Updatable updatable) {
     for (int index = 0; index < updatablesAndHandlers.length; index += 2) {
       if (updatablesAndHandlers[index] == updatable) {
-        ((WorkerHandler) updatablesAndHandlers[index + 1]).removeMessages(
-            WorkerHandler.MSG_CALL_UPDATABLE, updatable);
+        WorkerHandler handler = (WorkerHandler) updatablesAndHandlers[index + 1];
+        handler.removeUpdatable(updatable, token);
         updatablesAndHandlers[index] = null;
         updatablesAndHandlers[index + 1] = null;
         size--;
@@ -131,29 +140,31 @@ public abstract class BaseObservable implements Observable {
     throw new IllegalStateException("Updatable not added, cannot remove.");
   }
 
-  synchronized void sendUpdate() {
-    handler.removeMessages(WorkerHandler.MSG_UPDATE, this);
-    final long elapsedRealtimeMillis =
-        shortestUpdateWindowMillis > 0 ? elapsedRealtime() : 0;
-    final long timeFromLastUpdate = elapsedRealtimeMillis - lastUpdateTimestamp;
-    if (timeFromLastUpdate >= shortestUpdateWindowMillis) {
-      lastUpdateTimestamp = elapsedRealtimeMillis;
+  void sendUpdate() {
+    synchronized (token) {
+      if (!pendingUpdate) {
+        return;
+      }
+      if (shortestUpdateWindowMillis > 0) {
+        final long elapsedRealtimeMillis = elapsedRealtime();
+        final long timeFromLastUpdate = elapsedRealtimeMillis - lastUpdateTimestamp;
+        if (timeFromLastUpdate  < shortestUpdateWindowMillis) {
+          handler.sendMessageDelayed(handler.obtainMessage(WorkerHandler.MSG_UPDATE, this),
+              shortestUpdateWindowMillis - timeFromLastUpdate);
+          pendingUpdate = true;
+          return;
+        }
+        lastUpdateTimestamp = elapsedRealtimeMillis;
+      }
+      pendingUpdate = false;
       for (int index = 0; index < updatablesAndHandlers.length; index = index + 2) {
         final Updatable updatable = (Updatable) updatablesAndHandlers[index];
         final WorkerHandler handler =
             (WorkerHandler) updatablesAndHandlers[index + 1];
         if (updatable != null) {
-          if (handler.getLooper() == Looper.myLooper()) {
-            handler.removeMessages(WorkerHandler.MSG_CALL_UPDATABLE, updatable);
-            updatable.update();
-          } else if (!handler.hasMessages(WorkerHandler.MSG_CALL_UPDATABLE, updatable)) {
-            handler.obtainMessage(WorkerHandler.MSG_CALL_UPDATABLE, updatable).sendToTarget();
-          }
+          handler.update(updatable, token);
         }
       }
-    } else {
-      handler.sendMessageDelayed(handler.obtainMessage(WorkerHandler.MSG_UPDATE, this),
-          shortestUpdateWindowMillis - timeFromLastUpdate);
     }
   }
 

--- a/agera/src/main/java/com/google/android/agera/IdentityMultiMap.java
+++ b/agera/src/main/java/com/google/android/agera/IdentityMultiMap.java
@@ -1,0 +1,71 @@
+package com.google.android.agera;
+
+import android.support.annotation.NonNull;
+
+import java.util.Arrays;
+
+final class IdentityMultiMap<K, V> {
+  @NonNull
+  private static final Object[] NO_KEY_VALUES = new Object[0];
+
+  @NonNull
+  private Object[] keysValues;
+
+  IdentityMultiMap() {
+    this.keysValues = NO_KEY_VALUES;
+  }
+
+  @NonNull
+  Object[] getKeysValues() {
+    return keysValues;
+  }
+
+  synchronized boolean addKeyValuePair(@NonNull final K key, @NonNull final V value) {
+    int size = 0;
+    int indexToAdd = -1;
+    boolean hasValue = false;
+    for (int index = 0; index < keysValues.length; index += 2) {
+      final Object keysValue = keysValues[index];
+      if (keysValue == null) {
+        indexToAdd = index;
+      }
+      if (keysValue == key) {
+        size++;
+        if (keysValues[index + 1] == value) {
+          indexToAdd = index;
+          hasValue = true;
+        }
+      }
+    }
+    if (indexToAdd == -1) {
+      indexToAdd = keysValues.length;
+      keysValues = Arrays.copyOf(keysValues, indexToAdd < 2 ? 2 : indexToAdd * 2);
+    }
+    if (!hasValue) {
+      keysValues[indexToAdd] = key;
+      keysValues[indexToAdd + 1] = value;
+    }
+    return size == 0;
+  }
+
+  synchronized void removeKeyValuePair(@NonNull final K key, @NonNull final V value) {
+    for (int index = 0; index < keysValues.length; index += 2) {
+      if (keysValues[index] == keysValues && keysValues[index + 1] == value) {
+        keysValues[index] = null;
+        keysValues[index + 1] = null;
+      }
+    }
+  }
+
+  synchronized boolean removeKey(@NonNull final K key) {
+    boolean removed = false;
+    for (int index = 0; index < keysValues.length; index += 2) {
+      if (keysValues[index] == key) {
+        keysValues[index] = null;
+        keysValues[index + 1] = null;
+        removed = true;
+      }
+    }
+    return removed;
+  }
+}

--- a/agera/src/test/java/com/google/android/agera/test/matchers/UpdatableUpdated.java
+++ b/agera/src/test/java/com/google/android/agera/test/matchers/UpdatableUpdated.java
@@ -39,7 +39,13 @@ public final class UpdatableUpdated extends TypeSafeMatcher<MockUpdatable> {
 
   @Override
   public void describeTo(final Description description) {
-    description.appendText(updated ? "was updated" : "not updated");
+    description.appendText(updated ? "was updated" : "was not updated");
+  }
+
+  @Override
+  protected void describeMismatchSafely(final MockUpdatable item,
+      final Description mismatchDescription) {
+    mismatchDescription.appendText(updated ? "was not updated" : "was updated");
   }
 
   @NonNull


### PR DESCRIPTION
Use a simple boolean to track update from/to observable/updatable
instead of using the much slower handler.hasMessage method

Also removed the check for myLooper() in sendUpdate that slows down
updates (especially from other threads). This makes an update execute
faster but one cycle later, instead of slower, but this cycle