### PR TITLE
Fixing squid: S1213 The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/agera/src/main/java/com/google/android/agera/Conditions.java
+++ b/agera/src/main/java/com/google/android/agera/Conditions.java
@@ -26,6 +26,7 @@ import android.support.annotation.NonNull;
  */
 public final class Conditions {
 
+  private Conditions() {}
   /**
    * Returns a {@link Condition} that always returns {@code true}.
    */
@@ -181,5 +182,5 @@ public final class Conditions {
     }
   }
 
-  private Conditions() {}
+
 }

--- a/agera/src/main/java/com/google/android/agera/Functions.java
+++ b/agera/src/main/java/com/google/android/agera/Functions.java
@@ -33,6 +33,8 @@ import java.util.List;
  */
 public final class Functions {
 
+  private Functions() {}
+
   /**
    * Returns a {@link Function} that returns {@code object} as the result of each
    * {@link Function#apply} function call.
@@ -110,5 +112,4 @@ public final class Functions {
     }
   }
 
-  private Functions() {}
 }

--- a/agera/src/main/java/com/google/android/agera/Mergers.java
+++ b/agera/src/main/java/com/google/android/agera/Mergers.java
@@ -26,6 +26,7 @@ public final class Mergers {
 
   private static final ObjectsUnequalMerger OBJECTS_UNEQUAL_MERGER = new ObjectsUnequalMerger();
 
+  private Mergers() {}
   /**
    * Returns a {@link Merger} that outputs the given {@code value} regardless of the input values.
    */
@@ -52,5 +53,4 @@ public final class Mergers {
     }
   }
 
-  private Mergers() {}
 }

--- a/agera/src/main/java/com/google/android/agera/Observables.java
+++ b/agera/src/main/java/com/google/android/agera/Observables.java
@@ -37,6 +37,8 @@ import java.util.List;
  */
 public final class Observables {
 
+  private Observables() {}
+
   /**
    * Returns an {@link Observable} that notifies added {@link Updatable}s that any of the
    * {@code observables} have changed.
@@ -232,5 +234,4 @@ public final class Observables {
     }
   }
 
-  private Observables() {}
 }

--- a/agera/src/main/java/com/google/android/agera/Preconditions.java
+++ b/agera/src/main/java/com/google/android/agera/Preconditions.java
@@ -21,6 +21,9 @@ import android.support.annotation.NonNull;
  * Precondition checks.
  */
 public final class Preconditions {
+
+  private Preconditions() {}
+
   public static void checkState(final boolean expression, @NonNull final String errorMessage) {
     if (!expression) {
       throw new IllegalStateException(errorMessage);
@@ -42,5 +45,4 @@ public final class Preconditions {
     return object;
   }
 
-  private Preconditions() {}
 }

--- a/agera/src/main/java/com/google/android/agera/Predicates.java
+++ b/agera/src/main/java/com/google/android/agera/Predicates.java
@@ -27,6 +27,8 @@ import android.support.annotation.NonNull;
 public final class Predicates {
   private static final Predicate<CharSequence> EMPTY_STRING_PREDICATE = new EmptyStringPredicate();
 
+  private Predicates() {}
+
   /**
    * Returns a {@link Predicate} from a {@link Condition}.
    *
@@ -238,5 +240,4 @@ public final class Predicates {
     }
   }
 
-  private Predicates() {}
 }

--- a/agera/src/main/java/com/google/android/agera/Repositories.java
+++ b/agera/src/main/java/com/google/android/agera/Repositories.java
@@ -31,6 +31,8 @@ import android.support.annotation.NonNull;
  */
 public final class Repositories {
 
+  private Repositories() {}
+
   /**
    * Returns a static {@link Repository} of the given {@code object}.
    */
@@ -95,5 +97,4 @@ public final class Repositories {
     }
   }
 
-  private Repositories() {}
 }

--- a/agera/src/main/java/com/google/android/agera/RepositoryCompiler.java
+++ b/agera/src/main/java/com/google/android/agera/RepositoryCompiler.java
@@ -49,6 +49,31 @@ final class RepositoryCompiler implements
     RepositoryCompilerStates.RConfig {
 
   private static final ThreadLocal<RepositoryCompiler> compilers = new ThreadLocal<>();
+  private static final int NOTHING = 0;
+  private static final int FIRST_EVENT_SOURCE = 1;
+  private static final int FREQUENCY_OR_MORE_EVENT_SOURCE = 2;
+  private static final int FLOW = 3;
+  private static final int TERMINATE_THEN_FLOW = 4;
+  private static final int TERMINATE_THEN_END = 5;
+  private static final int CONFIG = 6;
+
+  private Object initialValue;
+  private final ArrayList<Observable> eventSources = new ArrayList<>();
+  private int frequency;
+  private final ArrayList<Object> directives = new ArrayList<>();
+  // 2x fields below: store caseExtractor and casePredicate for check(caseExtractor, casePredicate)
+  // for use in terminate(); if null then terminate() is terminating an attempt directive.
+  private Function caseExtractor;
+  private Predicate casePredicate;
+  private boolean goLazyUsed;
+  private Merger notifyChecker = objectsUnequal();
+  @RepositoryConfig
+  private int deactivationConfig;
+  @RepositoryConfig
+  private int concurrentUpdateConfig;
+
+  @Expect
+  private int expect;
 
   @NonNull
   static <TVal> RepositoryCompilerStates.REventSource<TVal, TVal> repositoryWithInitialValue(
@@ -76,31 +101,7 @@ final class RepositoryCompiler implements
       TERMINATE_THEN_FLOW, TERMINATE_THEN_END, CONFIG})
   private @interface Expect {}
 
-  private static final int NOTHING = 0;
-  private static final int FIRST_EVENT_SOURCE = 1;
-  private static final int FREQUENCY_OR_MORE_EVENT_SOURCE = 2;
-  private static final int FLOW = 3;
-  private static final int TERMINATE_THEN_FLOW = 4;
-  private static final int TERMINATE_THEN_END = 5;
-  private static final int CONFIG = 6;
 
-  private Object initialValue;
-  private final ArrayList<Observable> eventSources = new ArrayList<>();
-  private int frequency;
-  private final ArrayList<Object> directives = new ArrayList<>();
-  // 2x fields below: store caseExtractor and casePredicate for check(caseExtractor, casePredicate)
-  // for use in terminate(); if null then terminate() is terminating an attempt directive.
-  private Function caseExtractor;
-  private Predicate casePredicate;
-  private boolean goLazyUsed;
-  private Merger notifyChecker = objectsUnequal();
-  @RepositoryConfig
-  private int deactivationConfig;
-  @RepositoryConfig
-  private int concurrentUpdateConfig;
-
-  @Expect
-  private int expect;
 
   private RepositoryCompiler() {}
 

--- a/agera/src/main/java/com/google/android/agera/Reservoirs.java
+++ b/agera/src/main/java/com/google/android/agera/Reservoirs.java
@@ -34,6 +34,8 @@ import java.util.Queue;
  */
 public final class Reservoirs {
 
+  private Reservoirs() {}
+
   /**
    * Returns a {@link Reservoir} for the given value type.
    *
@@ -131,5 +133,4 @@ public final class Reservoirs {
     }
   }
 
-  private Reservoirs() {}
 }

--- a/agera/src/main/java/com/google/android/agera/Suppliers.java
+++ b/agera/src/main/java/com/google/android/agera/Suppliers.java
@@ -26,6 +26,8 @@ import android.support.annotation.NonNull;
  */
 public final class Suppliers {
 
+  private Suppliers() {}
+
   /**
    * Returns a {@link Supplier} that always supplies the given {@code object} when its
    * {@link Supplier#get()} is called.
@@ -64,5 +66,4 @@ public final class Suppliers {
     }
   }
 
-  private Suppliers() {}
 }

--- a/agera/src/main/java/com/google/android/agera/WorkerHandler.java
+++ b/agera/src/main/java/com/google/android/agera/WorkerHandler.java
@@ -18,6 +18,8 @@ final class WorkerHandler extends Handler {
   static final int MSG_CALL_ACKNOWLEDGE_CANCEL = 5;
   private static final ThreadLocal<WeakReference<WorkerHandler>> handlers = new ThreadLocal<>();
 
+  private WorkerHandler() {}
+
   @NonNull
   static WorkerHandler workerHandler() {
     final WeakReference<WorkerHandler> handlerReference = handlers.get();
@@ -29,7 +31,6 @@ final class WorkerHandler extends Handler {
     return handler;
   }
 
-  private WorkerHandler() {}
 
   @Override
   public void handleMessage(final Message message) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. This PR will remove 4h TD from the project.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
 Fevzi Ozgul