### PR TITLE
Fixing squid S1217  Thread.run() and Runnable.run() should not be called directly

### DIFF
--- a/agera/src/test/java/com/google/android/agera/RepositoriesTest.java
+++ b/agera/src/test/java/com/google/android/agera/RepositoriesTest.java
@@ -490,7 +490,8 @@ public final class RepositoriesTest {
   private static class SyncExecutor implements Executor {
     @Override
     public void execute(@NonNull final Runnable command) {
-      command.run();
+      Thread cmdThread = new Thread(command);
+      cmdThread.start();
     }
   }
 }

--- a/agera/src/test/java/com/google/android/agera/test/SingleSlotDelayedExecutor.java
+++ b/agera/src/test/java/com/google/android/agera/test/SingleSlotDelayedExecutor.java
@@ -45,6 +45,7 @@ public final class SingleSlotDelayedExecutor implements Executor {
         runnable, is(notNullValue()));
     this.runnable = null;
     //noinspection ConstantConditions
-    runnable.run();
+    Thread myThread = new Thread(runnable);
+    myThread.start();
   }
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1217 - “ Thread.run() and Runnable.run() should not be called directly”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1217
 Please let me know if you have any questions.
 Fevzi Ozgul