### PR TITLE
Added sort and thenSort directives to FunctionCompiler

### DIFF
--- a/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
+++ b/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
@@ -96,7 +96,7 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
 
   @NonNull
   @Override
-  public FunctionCompilerStates.FList sort(Comparator comparator) {
+  public FunctionCompilerStates.FList sort(@NonNull final Comparator comparator) {
     addFunction(new SortFunction(comparator));
     return this;
   }
@@ -230,8 +230,8 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
     @NonNull
     private final Comparator comparator;
 
-    public SortFunction(Comparator comparator) {
-      this.comparator = comparator;
+    SortFunction(@NonNull final Comparator comparator) {
+      this.comparator = checkNotNull(comparator);
     }
 
     @NonNull

--- a/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
+++ b/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
@@ -23,6 +23,8 @@ import static java.util.Collections.emptyList;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @SuppressWarnings("unchecked")
@@ -94,6 +96,13 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
 
   @NonNull
   @Override
+  public FunctionCompilerStates.FList sort(Comparator comparator) {
+    addFunction(new SortFunction(comparator));
+    return this;
+  }
+
+  @NonNull
+  @Override
   public FunctionCompilerStates.FList map(@NonNull final Function function) {
     if (function != IDENTITY_FUNCTION) {
       addFunction(new MapFunction(function));
@@ -119,6 +128,13 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
   @Override
   public Function thenLimit(final int limit) {
     limit(limit);
+    return createFunction();
+  }
+
+  @NonNull
+  @Override
+  public Function thenSort(@NonNull final Comparator comparator) {
+    sort(comparator);
     return createFunction();
   }
 
@@ -207,6 +223,22 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
         }
       }
       return result;
+    }
+  }
+
+  private static final class SortFunction<T> implements Function<List<T>, List<T>> {
+    @NonNull
+    private final Comparator comparator;
+
+    public SortFunction(Comparator comparator) {
+      this.comparator = comparator;
+    }
+
+    @NonNull
+    @Override
+    public List<T> apply(@NonNull List<T> input) {
+      Collections.sort(input, comparator);
+      return input;
     }
   }
 }

--- a/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
+++ b/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
@@ -236,7 +236,7 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
 
     @NonNull
     @Override
-    public List<T> apply(@NonNull List<T> input) {
+    public List<T> apply(@NonNull final List<T> input) {
       Collections.sort(input, comparator);
       return input;
     }

--- a/agera/src/main/java/com/google/android/agera/FunctionCompilerStates.java
+++ b/agera/src/main/java/com/google/android/agera/FunctionCompilerStates.java
@@ -119,7 +119,7 @@ public interface FunctionCompilerStates {
      * @param comparator the comparator to sort the items
      */
     @NonNull
-    FList<TPrev, TPrevList, TFrom> sort(Comparator<TPrev> comparator);
+    FList<TPrev, TPrevList, TFrom> sort(@NonNull Comparator<TPrev> comparator);
 
     /**
      * Adds a {@link Predicate} to the end of the behavior chain to filter out items.
@@ -143,6 +143,6 @@ public interface FunctionCompilerStates {
      * @param comparator the comparator to sort the items
      */
     @NonNull
-    Function<TFrom, TPrevList> thenSort(Comparator<TPrev> comparator);
+    Function<TFrom, TPrevList> thenSort(@NonNull Comparator<TPrev> comparator);
   }
 }

--- a/agera/src/main/java/com/google/android/agera/FunctionCompilerStates.java
+++ b/agera/src/main/java/com/google/android/agera/FunctionCompilerStates.java
@@ -17,6 +17,7 @@ package com.google.android.agera;
 
 import android.support.annotation.NonNull;
 
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -113,6 +114,14 @@ public interface FunctionCompilerStates {
     FList<TPrev, TPrevList, TFrom> limit(int limit);
 
     /**
+     * Adds a {@link Comparator} to the behavior chain to sort the items.
+     *
+     * @param comparator the comparator to sort the items
+     */
+    @NonNull
+    FList<TPrev, TPrevList, TFrom> sort(Comparator<TPrev> comparator);
+
+    /**
      * Adds a {@link Predicate} to the end of the behavior chain to filter out items.
      *
      * @param filter the predicate to filter by
@@ -127,5 +136,13 @@ public interface FunctionCompilerStates {
      */
     @NonNull
     Function<TFrom, TPrevList> thenLimit(int limit);
+
+    /**
+     * Adds a {@link Comparator} to the behavior chain to sort the items.
+     *
+     * @param comparator the comparator to sort the items
+     */
+    @NonNull
+    Function<TFrom, TPrevList> thenSort(Comparator<TPrev> comparator);
   }
 }

--- a/agera/src/test/java/com/google/android/agera/FunctionsTest.java
+++ b/agera/src/test/java/com/google/android/agera/FunctionsTest.java
@@ -44,6 +44,7 @@ import org.mockito.Mock;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public final class FunctionsTest {
@@ -171,6 +172,20 @@ public final class FunctionsTest {
         .thenMap(new StringLength());
 
     assertThat(function.apply(INPUT_LIST), contains(4, 7, 3));
+  }
+
+  @Test
+  public void shouldCreateFunctionFromListToSortedList() {
+    final Function<List<String>, List<Integer>> function = functionFromListOf(String.class)
+            .map(new StringLength())
+            .thenSort(new Comparator<Integer>() {
+              @Override
+              public int compare(Integer lhs, Integer rhs) {
+                return lhs.compareTo(rhs);
+              }
+            });
+
+    assertThat(function.apply(INPUT_LIST), contains(3, 4, 7, 7));
   }
 
   @Test


### PR DESCRIPTION
Although can use `morph (new SortList<T>())` to achieve the same
function, but I think sort is a very common function, should not let
each person alone to achieve a `SortList` Function. So I added the `sort` and `thenSort`
directives to make it more convenient.