### PR TITLE
Changed Result#failure to return absent given the absent failure

### DIFF
--- a/agera/src/main/java/com/google/android/agera/Result.java
+++ b/agera/src/main/java/com/google/android/agera/Result.java
@@ -69,7 +69,8 @@ public final class Result<T> {
    */
   @NonNull
   public static <T> Result<T> failure(@NonNull final Throwable failure) {
-    return new Result<>(null, checkNotNull(failure));
+    return failure == ABSENT_THROWABLE
+        ? Result.<T>absent() : new Result<T>(null, checkNotNull(failure));
   }
 
   /**


### PR DESCRIPTION
Can potentially happen when directly wrapping a throwable in .attemptX
.orEnd (for instance .orEnd(Result::failure))