### PR TITLE
Added RetrofitAgeraCallAdapter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ To add dependencies to these using Gradle:
   compile 'com.google.android.agera:rvdatabinding:1.1.0-beta1'
 ```
 
+Maybe you are using Retrofit, then you might like [retrofit agera call adapter](https://github.com/drakeet/retrofit-agera-call-adapter):
+
+```groovy
+  compile 'me.drakeet.retrofit2:adapter-agera:2.0.2'
+```
+
+
 FAQ: What's the relation with RxJava?
 -----
 See [this issue](https://github.com/google/agera/issues/20).


### PR DESCRIPTION
I have developed a [AgeraCallAdapterFactory](https://github.com/drakeet/retrofit-agera-call-adapter) for [Retrofit](https://square.github.io/retrofit/), this is its [sample](https://github.com/drakeet/retrofit-agera-call-adapter):


<img src="http://ww2.sinaimg.cn/large/86e2ff85gw1f4hawi7r5aj214a16qtnj.jpg" width=439 height=466/>



And in order to avoid writing some duplicate code every time, I write a class:


```java
public class Ageras {

    public static <T> RFlow<T, T, ?> goToBackgroundWithInitialValue(@NonNull final T initialValue) {
        return repositoryWithInitialValue(initialValue)
            .observe()
            .onUpdatesPerLoop()
            .goTo(Executors.newSingleThreadExecutor());
    }
}
```


How about adding the [RetrofitAgeraCallAdapter](https://github.com/drakeet/retrofit-agera-call-adapter) as a new sample extension to README?

Thanks!
