### PR TITLE
Changed sort not to mutate input list

### DIFF
--- a/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
+++ b/agera/src/main/java/com/google/android/agera/FunctionCompiler.java
@@ -237,8 +237,9 @@ final class FunctionCompiler implements FunctionCompilerStates.FList, FunctionCo
     @NonNull
     @Override
     public List<T> apply(@NonNull final List<T> input) {
-      Collections.sort(input, comparator);
-      return input;
+      final List<T> output = new ArrayList<>(input);
+      Collections.sort(output, comparator);
+      return output;
     }
   }
 }

--- a/agera/src/test/java/com/google/android/agera/FunctionsTest.java
+++ b/agera/src/test/java/com/google/android/agera/FunctionsTest.java
@@ -185,7 +185,23 @@ public final class FunctionsTest {
               }
             });
 
-    assertThat(function.apply(INPUT_LIST), contains(3, 4, 7, 7));
+    final List<String> inputList = new ArrayList<>(INPUT_LIST);
+    assertThat(function.apply(inputList), contains(3, 4, 7, 7));
+  }
+
+  @Test
+  public void shouldNotMutateInputListWhenSorting() {
+    final Function<List<String>, List<String>> function = functionFromListOf(String.class)
+        .thenSort(new Comparator<String>() {
+          @Override
+          public int compare(String lhs, String rhs) {
+            return lhs.compareTo(rhs);
+          }
+        });
+
+    final List<String> inputList = new ArrayList<>(INPUT_LIST);
+    assertThat(function.apply(inputList), contains("for", "some", "strings", "testing"));
+    assertThat(inputList, is(INPUT_LIST));
   }
 
   @Test


### PR DESCRIPTION
Not only prevents mutating other classes data, but allows to sort immutable input