### PR TITLE
Changed DBColumn columns' value to be nullable

### DIFF
--- a/extensions/database/src/main/java/com/google/android/agera/database/SqlRequestCompiler.java
+++ b/extensions/database/src/main/java/com/google/android/agera/database/SqlRequestCompiler.java
@@ -32,6 +32,7 @@ import com.google.android.agera.database.SqlRequestCompilerStates.DBWhereCompile
 
 import android.content.ContentValues;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 @SuppressWarnings({"unchecked, rawtypes"})
 final class SqlRequestCompiler
@@ -90,73 +91,73 @@ final class SqlRequestCompiler
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final String value) {
+  public Object column(@NonNull final String column, @Nullable final String value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Byte value) {
+  public Object column(@NonNull final String column, @Nullable final Byte value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Short value) {
+  public Object column(@NonNull final String column, @Nullable final Short value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Integer value) {
+  public Object column(@NonNull final String column, @Nullable final Integer value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Long value) {
+  public Object column(@NonNull final String column, @Nullable final Long value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Float value) {
+  public Object column(@NonNull final String column, @Nullable final Float value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Double value) {
+  public Object column(@NonNull final String column, @Nullable final Double value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final Boolean value) {
+  public Object column(@NonNull final String column, @Nullable final Boolean value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 
   @NonNull
   @Override
-  public Object column(@NonNull final String column, @NonNull final byte[] value) {
+  public Object column(@NonNull final String column, @Nullable final byte[] value) {
     checkState(!compiled, ERROR_MESSAGE);
-    contentValues.put(checkNotNull(column), checkNotNull(value));
+    contentValues.put(checkNotNull(column), value);
     return this;
   }
 

--- a/extensions/database/src/main/java/com/google/android/agera/database/SqlRequestCompilerStates.java
+++ b/extensions/database/src/main/java/com/google/android/agera/database/SqlRequestCompilerStates.java
@@ -16,6 +16,7 @@
 package com.google.android.agera.database;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * Container of the compiler state interfaces supporting the creation of sql requests.
@@ -75,55 +76,55 @@ public interface SqlRequestCompilerStates {
      * Adds a {@code column} with a {@link String} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull String value);
+    T column(@NonNull String column, @Nullable String value);
 
     /**
      * Adds a {@code column} with a {@link Byte} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Byte value);
+    T column(@NonNull String column, @Nullable Byte value);
 
     /**
      * Adds a {@code column} with a {@link Short} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Short value);
+    T column(@NonNull String column, @Nullable Short value);
 
     /**
      * Adds a {@code column} with a {@link Integer} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Integer value);
+    T column(@NonNull String column, @Nullable Integer value);
 
     /**
      * Adds a {@code column} with a {@link Long} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Long value);
+    T column(@NonNull String column, @Nullable Long value);
 
     /**
      * Adds a {@code column} with a {@link Float} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Float value);
+    T column(@NonNull String column, @Nullable Float value);
 
     /**
      * Adds a {@code column} with a {@link Double} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Double value);
+    T column(@NonNull String column, @Nullable Double value);
 
     /**
      * Adds a {@code column} with a {@link Boolean} {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull Boolean value);
+    T column(@NonNull String column, @Nullable Boolean value);
 
     /**
      * Adds a {@code column} with a {@code byte} array {@code value}.
      */
     @NonNull
-    T column(@NonNull String column, @NonNull byte[] value);
+    T column(@NonNull String column, @Nullable byte[] value);
 
     /**
      * Adds an empty {@code column}.

--- a/extensions/database/src/test/java/com/google/android/agera/database/SqlDatabaseFunctionsTest.java
+++ b/extensions/database/src/test/java/com/google/android/agera/database/SqlDatabaseFunctionsTest.java
@@ -347,6 +347,16 @@ public final class SqlDatabaseFunctionsTest {
   }
 
   @Test
+  public void shouldAddNullBooleanColumnForInsert() {
+    final Boolean nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsBoolean(COLUMN),
+        is(nullValue));
+  }
+
+  @Test
   public void shouldAddStringColumnForInsert() {
     final String value = "string";
     assertThat(sqlInsertRequest()
@@ -354,6 +364,16 @@ public final class SqlDatabaseFunctionsTest {
             .column(COLUMN, value)
             .compile().contentValues.getAsString(COLUMN),
         is(value));
+  }
+
+  @Test
+  public void shouldAddNullStringColumnForInsert() {
+    final String nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsString(COLUMN),
+        is(nullValue));
   }
 
   @Test
@@ -367,6 +387,16 @@ public final class SqlDatabaseFunctionsTest {
   }
 
   @Test
+  public void shouldAddNullByteColumnForInsert() {
+    final Byte nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsByte(COLUMN),
+        is(nullValue));
+  }
+
+  @Test
   public void shouldAddIntegerColumnForInsert() {
     final int value = 2;
     assertThat(sqlInsertRequest()
@@ -374,6 +404,16 @@ public final class SqlDatabaseFunctionsTest {
             .column(COLUMN, value)
             .compile().contentValues.getAsInteger(COLUMN),
         is(value));
+  }
+
+  @Test
+  public void shouldAddNullIntegerColumnForInsert() {
+    final Integer nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsInteger(COLUMN),
+        is(nullValue));
   }
 
   @Test
@@ -387,6 +427,16 @@ public final class SqlDatabaseFunctionsTest {
   }
 
   @Test
+  public void shouldAddNullShortColumnForInsert() {
+    final Short nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsShort(COLUMN),
+        is(nullValue));
+  }
+
+  @Test
   public void shouldAddDoubleColumnForInsert() {
     final double value = 2;
     assertThat(sqlInsertRequest()
@@ -394,6 +444,16 @@ public final class SqlDatabaseFunctionsTest {
             .column(COLUMN, value)
             .compile().contentValues.getAsDouble(COLUMN),
         is(value));
+  }
+
+  @Test
+  public void shouldAddNullDoubleColumnForInsert() {
+    final Double nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsDouble(COLUMN),
+        is(nullValue));
   }
 
   @Test
@@ -407,6 +467,16 @@ public final class SqlDatabaseFunctionsTest {
   }
 
   @Test
+  public void shouldAddNullFloatColumnForInsert() {
+    final Float nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsFloat(COLUMN),
+        is(nullValue));
+  }
+
+  @Test
   public void shouldAddLongColumnForInsert() {
     final long value = 2;
     assertThat(sqlInsertRequest()
@@ -417,6 +487,16 @@ public final class SqlDatabaseFunctionsTest {
   }
 
   @Test
+  public void shouldAddNullLongColumnForInsert() {
+    final Long nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsLong(COLUMN),
+        is(nullValue));
+  }
+
+  @Test
   public void shouldAddByteArrayColumnForInsert() {
     final byte[] value = "value".getBytes();
     assertThat(sqlInsertRequest()
@@ -424,6 +504,16 @@ public final class SqlDatabaseFunctionsTest {
             .column(COLUMN, value)
             .compile().contentValues.getAsByteArray(COLUMN),
         is(value));
+  }
+
+  @Test
+  public void shouldAddNullByteArrayColumnForInsert() {
+    final byte[] nullValue = null;
+    assertThat(sqlInsertRequest()
+            .table(TABLE)
+            .column(COLUMN, nullValue)
+            .compile().contentValues.getAsByteArray(COLUMN),
+        is(nullValue));
   }
 
   @Test


### PR DESCRIPTION
Prior to this, the `column` does not support `null` value, leading us have
to use `NonNull` column value, and in fact, we may need `Nullable` value in
DB and the `put`s method of `ContentValues` support `Nullable` value. Maybe
you'll say `emptyColumn` can do it, but actually it's hard to use it. So
I use `Nullable` instead of `Nullable` for the value argument. It will be
convenient.