### PR TITLE
Added explicit action filtering to BroadcastObservable

### DIFF
--- a/extensions/content/src/main/java/com/google/android/agera/content/ContentObservables.java
+++ b/extensions/content/src/main/java/com/google/android/agera/content/ContentObservables.java
@@ -82,16 +82,18 @@ public final class ContentObservables {
     BroadcastObservable(@NonNull final Context applicationContext,
         @NonNull final String... actions) {
       this.context = checkNotNull(applicationContext);
-      this.broadcastReceiver = new BroadcastReceiver() {
-        @Override
-        public void onReceive(final Context context, final Intent intent) {
-          dispatchUpdate();
-        }
-      };
       this.filter = new IntentFilter();
       for (final String action : actions) {
         this.filter.addAction(action);
       }
+      this.broadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+          if (filter.hasAction(intent.getAction())) {
+            dispatchUpdate();
+          }
+        }
+      };
     }
 
     @Override


### PR DESCRIPTION
According to the [BroadcastReceiver doc](https://developer.android.com/reference/android/content/BroadcastReceiver.html#onReceive(android.content.Context, android.content.Intent)), `onReceive()` implementations should respond only to known actions, ignoring any unexpected Intents that they may receive.