### PR TITLE
RecyclerView stable ids for rvadapter/databinding repository presenters.

### DIFF
--- a/extensions/rvadapter/src/main/java/com/google/android/agera/rvadapter/RepositoryPresenterCompilerStates.java
+++ b/extensions/rvadapter/src/main/java/com/google/android/agera/rvadapter/RepositoryPresenterCompilerStates.java
@@ -69,6 +69,25 @@ public interface RepositoryPresenterCompilerStates {
   }
 
   /**
+   * Compiler state to specify how to generate stable IDs when
+   * {@link android.support.v7.widget.RecyclerView.Adapter#setHasStableIds(boolean)} is true.
+   */
+  interface RPStableId<TVal, TRet> {
+
+    /**
+     * Specifies a {@link Function} providing a stable id for the given item.
+     * Called only if stable IDs are enabled with {@link RepositoryAdapter#setHasStableIds
+     * RepositoryAdapter.setHasStableIds(true)}, and therefore this method is optional with a
+     * default implementation of returning {@link RecyclerView#NO_ID}. If stable IDs are enabled,
+     * the returned ID and the layout returned by {@link RPLayout#layoutForItem(Function)} or
+     * {@link RPLayout#layout(int)} for the given item should together uniquely identify this item
+     * in the whole {@link RecyclerView} throughout all changes.
+     */
+    @NonNull
+    TRet stableIdForItem(@NonNull Function<TVal, Long> stableIdForItem);
+  }
+
+  /**
    * Compiler state to create the @{link RepositoryPresenter}.
    */
   interface RPCompile<TVal> {
@@ -99,6 +118,11 @@ public interface RepositoryPresenterCompilerStates {
   /**
    * Compiler state allowing to specify view binder, view recycler or compile.
    */
-  interface RPViewBinderCompile<TVal>
-      extends RPViewBinder<TVal, RPCompile<TVal>>, RPCompile<TVal> {}
+  interface RPViewBinderCompile<TVal> extends RPViewBinder<TVal, RPCompile<TVal>>,
+      RPCompile<TVal> {}
+  /**
+   * Compiler state allowing to specify view binder, view recycler, stable id function or compile.
+   */
+  interface RPViewBinderStableIdCompile<TVal> extends RPViewBinderCompile<TVal>,
+      RPStableId<TVal, RPViewBinderCompile<TVal>> {}
 }

--- a/extensions/rvadapter/src/main/java/com/google/android/agera/rvadapter/RepositoryPresenters.java
+++ b/extensions/rvadapter/src/main/java/com/google/android/agera/rvadapter/RepositoryPresenters.java
@@ -18,7 +18,7 @@ package com.google.android.agera.rvadapter;
 import com.google.android.agera.Repository;
 import com.google.android.agera.Result;
 import com.google.android.agera.rvadapter.RepositoryPresenterCompilerStates.RPLayout;
-import com.google.android.agera.rvadapter.RepositoryPresenterCompilerStates.RPViewBinderCompile;
+import com.google.android.agera.rvadapter.RepositoryPresenterCompilerStates.RPViewBinderStableIdCompile;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -37,7 +37,7 @@ public final class RepositoryPresenters {
    */
   @SuppressWarnings({"unchecked", "UnusedParameters"})
   @NonNull
-  public static <T> RPLayout<T, RPViewBinderCompile<T>> repositoryPresenterOf(
+  public static <T> RPLayout<T, RPViewBinderStableIdCompile<T>> repositoryPresenterOf(
       @Nullable final Class<T> type) {
     return new RepositoryPresenterCompiler();
   }

--- a/extensions/rvadapter/src/test/java/com/google/android/agera/rvadapter/RepositoryPresentersTest.java
+++ b/extensions/rvadapter/src/test/java/com/google/android/agera/rvadapter/RepositoryPresentersTest.java
@@ -13,6 +13,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.android.agera.Binder;
 import com.google.android.agera.Function;
+import com.google.android.agera.Functions;
 import com.google.android.agera.Result;
 
 import android.support.v7.widget.RecyclerView;
@@ -39,6 +40,7 @@ public class RepositoryPresentersTest {
   private static final Result<List<String>> LIST_FAILURE = Result.<List<String>>failure();
   private static final int LAYOUT_ID = 0;
   private static final int DYNAMIC_LAYOUT_ID = 1;
+  private static final long STABLE_ID = 2;
   @Mock
   private Binder<String, View> binder;
   @Mock
@@ -161,5 +163,46 @@ public class RepositoryPresentersTest {
   @Test
   public void shouldHavePrivateConstructor() {
     assertThat(RepositoryPresenters.class, hasPrivateConstructor());
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfResult() {
+    final RepositoryPresenter<Result<String>> resultRepositoryPresenter =
+        repositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+            .forResult();
+    assertThat(resultRepositoryPresenter.getItemId(STRING_RESULT, 0), is(STABLE_ID));
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfResultList() {
+    final RepositoryPresenter<Result<List<String>>> resultListRepositoryPresenter =
+        repositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+            .forResultList();
+    assertThat(resultListRepositoryPresenter.getItemId(STRING_LIST_RESULT, 1), is(STABLE_ID));
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfList() {
+    final RepositoryPresenter<List<String>> listRepositoryPresenter =
+        repositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+            .forList();
+    assertThat(listRepositoryPresenter.getItemId(STRING_LIST, 1), is(STABLE_ID));
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfListWithBinder() {
+    final RepositoryPresenter<List<String>> resultRepositoryPresenter =
+        repositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+            .bindWith(binder)
+            .forList();
+    assertThat(resultRepositoryPresenter.getItemId(STRING_LIST, 1), is(STABLE_ID));
   }
 }

--- a/extensions/rvdatabinding/src/main/java/com/google/android/agera/rvdatabinding/DataBindingRepositoryPresenterCompiler.java
+++ b/extensions/rvdatabinding/src/main/java/com/google/android/agera/rvdatabinding/DataBindingRepositoryPresenterCompiler.java
@@ -34,6 +34,7 @@ import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.Pair;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
 import java.util.ArrayList;
@@ -46,6 +47,8 @@ final class DataBindingRepositoryPresenterCompiler
   private final List<Pair<Integer, Object>> handlers;
   private Function<Object, Integer> layoutFactory;
   private Function itemId;
+  @NonNull
+  private Function<Object, Long> stableIdForItem = staticFunction(RecyclerView.NO_ID);
 
   DataBindingRepositoryPresenterCompiler() {
     this.handlers = new ArrayList<>();
@@ -77,6 +80,7 @@ final class DataBindingRepositoryPresenterCompiler
   public RepositoryPresenter<List<Object>> forList() {
     return repositoryPresenterOf(null)
         .layoutForItem(layoutFactory)
+        .stableIdForItem(stableIdForItem)
         .bindWith(new ViewBinder(itemId, new ArrayList<>(handlers)))
         .forList();
   }
@@ -86,6 +90,7 @@ final class DataBindingRepositoryPresenterCompiler
   public RepositoryPresenter<Result<Object>> forResult() {
     return repositoryPresenterOf(Object.class)
         .layoutForItem(layoutFactory)
+        .stableIdForItem(stableIdForItem)
         .bindWith(new ViewBinder(itemId, new ArrayList<>(handlers)))
         .forResult();
   }
@@ -95,6 +100,7 @@ final class DataBindingRepositoryPresenterCompiler
   public RepositoryPresenter<Result<List<Object>>> forResultList() {
     return repositoryPresenterOf(null)
         .layoutForItem(layoutFactory)
+        .stableIdForItem(stableIdForItem)
         .bindWith(new ViewBinder(itemId, new ArrayList<>(handlers)))
         .forResultList();
   }
@@ -110,6 +116,13 @@ final class DataBindingRepositoryPresenterCompiler
   @Override
   public Object layoutForItem(@NonNull Function layoutForItem) {
     this.layoutFactory = checkNotNull(layoutForItem);
+    return this;
+  }
+
+  @NonNull
+  @Override
+  public Object stableIdForItem(@NonNull final Function stableIdForItem) {
+    this.stableIdForItem = stableIdForItem;
     return this;
   }
 

--- a/extensions/rvdatabinding/src/main/java/com/google/android/agera/rvdatabinding/DataBindingRepositoryPresenterCompilerStates.java
+++ b/extensions/rvdatabinding/src/main/java/com/google/android/agera/rvdatabinding/DataBindingRepositoryPresenterCompilerStates.java
@@ -17,6 +17,7 @@ package com.google.android.agera.rvdatabinding;
 
 import com.google.android.agera.Function;
 import com.google.android.agera.rvadapter.RepositoryPresenterCompilerStates.RPCompile;
+import com.google.android.agera.rvadapter.RepositoryPresenterCompilerStates.RPStableId;
 
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
@@ -36,5 +37,6 @@ public interface DataBindingRepositoryPresenterCompilerStates {
   }
 
   interface DBRPHandlerBindingCompile<TVal>
-      extends RPCompile<TVal>, DBRPHandlerBinding<DBRPHandlerBindingCompile<TVal>> {}
+      extends RPCompile<TVal>, DBRPHandlerBinding<DBRPHandlerBindingCompile<TVal>>,
+      RPStableId<TVal, DBRPHandlerBindingCompile<TVal>> {}
 }

--- a/extensions/rvdatabinding/src/test/java/com/google/android/agera/rvdatabinding/DataBindingRepositoryPresentersTest.java
+++ b/extensions/rvdatabinding/src/test/java/com/google/android/agera/rvdatabinding/DataBindingRepositoryPresentersTest.java
@@ -13,6 +13,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.android.agera.Binder;
 import com.google.android.agera.Function;
+import com.google.android.agera.Functions;
 import com.google.android.agera.Result;
 import com.google.android.agera.rvadapter.RepositoryPresenter;
 
@@ -46,6 +47,7 @@ public class DataBindingRepositoryPresentersTest {
   private static final int DYNAMIC_ITEM_ID = 4;
   private static final int HANDLER_ID = 5;
   private static final int SECOND_HANDLER_ID = 6;
+  private static final long STABLE_ID = 2;
   @Mock
   private Binder<String, View> binder;
   @Mock
@@ -186,6 +188,39 @@ public class DataBindingRepositoryPresentersTest {
             .itemIdForItem(itemIdForItem)
             .forResultList();
     resultListRepositoryPresenter.bind(STRING_LIST_RESULT, 1, viewHolder);
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfResult() {
+    final RepositoryPresenter<Result<String>> resultRepositoryPresenter =
+        dataBindingRepositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .itemId(ITEM_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+        .forResult();
+    assertThat(resultRepositoryPresenter.getItemId(STRING_RESULT, 0), is(STABLE_ID));
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfResultList() {
+    final RepositoryPresenter<Result<List<String>>> resultListRepositoryPresenter =
+        dataBindingRepositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .itemId(ITEM_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+            .forResultList();
+    assertThat(resultListRepositoryPresenter.getItemId(STRING_LIST_RESULT, 0), is(STABLE_ID));
+  }
+
+  @Test
+  public void shouldReturnStableIdForRepositoryPresenterOfList() {
+    final RepositoryPresenter<List<String>> listRepositoryPresenter =
+        dataBindingRepositoryPresenterOf(String.class)
+            .layout(LAYOUT_ID)
+            .itemId(ITEM_ID)
+            .stableIdForItem(Functions.<String, Long>staticFunction(STABLE_ID))
+            .forList();
+    assertThat(listRepositoryPresenter.getItemId(STRING_LIST, 0), is(STABLE_ID));
   }
 
   @Test

--- a/testapp/src/main/java/com/google/android/agera/testapp/NotesActivity.java
+++ b/testapp/src/main/java/com/google/android/agera/testapp/NotesActivity.java
@@ -90,6 +90,7 @@ public final class NotesActivity extends Activity {
         .add(notesStore.getNotesRepository(), dataBindingRepositoryPresenterOf(Note.class)
             .layout(R.layout.text_layout)
             .itemId(com.google.android.agera.testapp.BR.note)
+            .stableIdForItem(input -> (long) input.getId())
             .handler(com.google.android.agera.testapp.BR.click,
                 (Receiver<Note>) note -> {
                   final EditText editText = new EditText(this);
@@ -106,6 +107,7 @@ public final class NotesActivity extends Activity {
                 (Predicate<Note>) notesStore::deleteNote)
             .forList())
         .whileStarted(this);
+    adapter.setHasStableIds(true);
 
     // Setup the recycler view using the repository adapter
     final RecyclerView recyclerView = (RecyclerView) findViewById(R.id.result);

--- a/testapp/src/main/java/com/google/android/agera/testapp/NotesStore.java
+++ b/testapp/src/main/java/com/google/android/agera/testapp/NotesStore.java
@@ -64,7 +64,7 @@ final class NotesStore {
   private static final String MODIFY_NOTE_WHERE = NOTES_NOTE_ID_COLUMN + "=?";
   private static final String GET_NOTES_FROM_TABLE =
       "SELECT " + NOTES_NOTE_ID_COLUMN + ", " + NOTES_NOTE_COLUMN + " FROM " + NOTES_TABLE
-          + " ORDER BY " + NOTES_NOTE_ID_COLUMN;
+          + " ORDER BY " + NOTES_NOTE_COLUMN;
   private static final int ID_COLUMN_INDEX = 0;
   private static final int NOTE_COLUMN_INDEX = 1;
   private static final List<Note> INITIAL_VALUE = emptyList();


### PR DESCRIPTION
Modified the testapp to use stable ids.
  Notes are sorted on their content text instead of ID.
  Whenever the content is changed causing a reorder,
  notice the animations caused by the RecyclerView ItemAnimator.