### PR TITLE
Clear out test app recyclerview ref. in onDestroyView

### DIFF
--- a/testapp/src/main/java/com/google/android/agera/testapp/NotesFragment.java
+++ b/testapp/src/main/java/com/google/android/agera/testapp/NotesFragment.java
@@ -156,5 +156,6 @@ public final class NotesFragment extends Fragment {
   public void onDestroyView() {
     super.onDestroyView();
     recyclerView.setAdapter(null);
+    recyclerView = null;
   }
 }


### PR DESCRIPTION
Not needed in this particular case, but good practice either way.